### PR TITLE
Add a publishable tests CI workflow

### DIFF
--- a/resources/workflows/auth.yml
+++ b/resources/workflows/auth.yml
@@ -1,0 +1,60 @@
+name: DevDojo Auth Tests
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.2'
+        extensions: mbstring, xml, ctype, iconv, mysql
+
+    - name: Cache Composer Packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.composer/cache
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-git
+
+    - name: Install Dependencies
+      run: composer install --no-progress --prefer-dist
+
+    - name: Remove current tests and symlink to DevDojo Auth
+      run: |
+        rm -rf tests
+        ln -s vendor/devdojo/auth/tests tests
+
+    - name: Create sqlite file
+      run: touch database/database.sqlite
+
+    - name: List out .env
+      run: cat .env
+
+    - name: Updating values in the .env
+      run: |
+        sed -i 's/DB_CONNECTION=mysql/DB_CONNECTION=sqlite/' .env
+        sed -i 's/^DB_DATABASE=laravel/#DB_DATABASE=laravel/' .env
+
+    - name: Run the migrations
+      run: php artisan migrate
+
+    - name: Run the Auth Migrations
+      run: php artisan migrate --path=vendor/devdojo/auth/database/migrations 
+
+    - name: Install PestPHP
+      run: composer require pestphp/pest --dev --with-all-dependencies
+
+    - name: Run Tests
+      run: ./vendor/bin/pest
+

--- a/src/AuthServiceProvider.php
+++ b/src/AuthServiceProvider.php
@@ -50,6 +50,11 @@ class AuthServiceProvider extends ServiceProvider
                 __DIR__.'/../public' => public_path('auth'),
             ], 'auth:assets');
 
+            // Publishing CI workflows.
+            $this->publishes([
+                __DIR__.'/../resources/workflows' => base_path('.github/workflows'),
+            ], 'auth:ci');
+
             // Publishing the translation files.
             /*$this->publishes([
                 __DIR__.'/../resources/lang' => resource_path('lang/vendor/auth'),


### PR DESCRIPTION
Adding a publishable CI workflow file that users could publish using:

```bash
php artisan vendor:publish --tag=auth:ci   
```

Then they would be able to run all of the Auth package tests within their own apps on every pull request.