### PR TITLE
Update SocialProviderUser.php

### DIFF
--- a/src/Models/SocialProviderUser.php
+++ b/src/Models/SocialProviderUser.php
@@ -9,6 +9,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class SocialProviderUser extends Model
 {
     protected $table = 'social_provider_user';
+    
+    // Prevents the "returning id" default behaviour
+    protected $primaryKey = ['user_id', 'provider_slug'];
+    // Prevents the auto-increment default behaviour
+    public $incrementing = false;
 
     // Indicates if the model should be timestamped.
     public $timestamps = true;


### PR DESCRIPTION
Fixing Issue > Error saving on social_provider_user table after Google Login thedevdojo#51:

SQLSTATE[42703]: Undefined column: 7 ERROR: colunmn "id" doesn't exists LINE 1: ..., $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) returning "id" ^ (Connection: pgsql, SQL: insert into "social_provider_user" ("provider_user_id", "nickname", "name", "email", "avatar", "provider_data", "token", "refresh_token", "token_expires_at", "provider_slug", "user_id", "updated_at", "created_at") values (XXXXXX, ?, XXXXXXXX, XXXXXX@gmail.com, https://lh3.googleusercontent.com/a/XXXXXXX"{\"sub\":\"XXXXXXX\",\"name\":\"XXXXXXX\",\"given_name\":\"XXXXXX\",\"family_name\":\"XXXXXX\",\"picture\":\"https:\\\/\\\/lh3.googleusercontent.com\\\/a\\\/XXXXXXXc\",\"email\":\"XXXXXXX@gmail.com\",\"email_verified\":true,\"id\":\"XXXXXXXXXXXXX\",\"verified_email\":true,\"link\":null}", XXXXXXX, ?, 2024-06-21 21:07:26, google, 1, 2024-06-21 20:07:27, 2024-06-21 20:07:27) returning "id")