### PR TITLE
Adding latest update to new model

### DIFF
--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -78,7 +78,6 @@ new class extends Component
         $this->validate();
 
         $credentials = ['email' => $this->email, 'password' => $this->password];
-
         if(!\Auth::validate($credentials)){
             $this->addError('password', trans('auth.failed'));
             return;

--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\User;
 use Illuminate\Auth\Events\Login;
 use function Laravel\Folio\{middleware, name};
 use Livewire\Attributes\Validate;
@@ -34,6 +33,8 @@ new class extends Component
 
     public $userSocialProviders = [];
 
+    public $userModel = null;
+
     public function mount(){
         $this->loadConfigs();
         $this->twoFactorEnabled = $this->settings->enable_2fa;
@@ -54,7 +55,7 @@ new class extends Component
 
         if(!$this->showPasswordField){
             $this->validateOnly('email');
-            $userTryingToValidate = \Devdojo\Auth\Models\User::where('email', $this->email)->first();
+            $userTryingToValidate = $this->userModel->where('email', $this->email)->first();
             if(!is_null($userTryingToValidate)){
                 if(is_null($userTryingToValidate->password)){
                     $this->userSocialProviders = [];
@@ -82,7 +83,7 @@ new class extends Component
             return;
         }
 
-        $userAttemptingLogin = User::where('email', $this->email)->first();
+        $userAttemptingLogin = $this->userModel->where('email', $this->email)->first();
 
         if(!isset($userAttemptingLogin->id)){
             $this->addError('password', trans('auth.failed'));
@@ -102,7 +103,8 @@ new class extends Component
                 $this->addError('password', trans('auth.failed'));
                 return;
             }
-            event(new Login(auth()->guard('web'), User::where('email', $this->email)->first(), true));
+            
+            event(new Login(auth()->guard('web'), $this->userModel->where('email', $this->email)->first(), true));
 
             if(session()->get('url.intended') != route('logout.get')){
                 redirect()->intended(config('devdojo.auth.settings.redirect_after_auth'));

--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -38,6 +38,7 @@ new class extends Component
     public function mount(){
         $this->loadConfigs();
         $this->twoFactorEnabled = $this->settings->enable_2fa;
+        $this->userModel = app(config('auth.providers.users.model'));
     }
 
     public function editIdentity(){

--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -46,7 +46,7 @@ new class extends Component
             $this->showPasswordField = false;
             return;
         }
-
+        
         $this->showIdentifierInput = true;
         $this->showSocialProviderInfo = false;
     }
@@ -78,6 +78,7 @@ new class extends Component
         $this->validate();
 
         $credentials = ['email' => $this->email, 'password' => $this->password];
+
         if(!\Auth::validate($credentials)){
             $this->addError('password', trans('auth.failed'));
             return;

--- a/resources/views/pages/auth/register.blade.php
+++ b/resources/views/pages/auth/register.blade.php
@@ -1,6 +1,5 @@
 <?php
 
-use Devdojo\Auth\Models\User;
 use Devdojo\Auth\Models\SocialProvider;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
@@ -84,7 +83,7 @@ new class extends Component
             $userData['name'] = $this->name;
         }
 
-        $user = User::create($userData);
+        $user = app(config('auth.providers.users.model'))->create($userData);
 
         event(new Registered($user));
 


### PR DESCRIPTION
This is an updated PR that pulled in the latest from this PR: https://github.com/thedevdojo/auth/pull/39

This will use the default user model provided inside of `config('auth.providers.users.model')`. Making the user creation easier to extend for the user.