### PR TITLE
Required imagick extension

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.2'
-        extensions: mbstring, xml, ctype, iconv, mysql
+        extensions: mbstring, xml, ctype, iconv, mysql, imagick
 
     - name: Cache Composer Packages
       uses: actions/cache@v2

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0|^8.1|^8.2",
+		"ext-imagick": "^3.4",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
         "laravel/folio": "^1.0",
         "livewire/livewire": "^3.0",


### PR DESCRIPTION
The `BaconQrCode` package required the `imagick` extension to work. I added the `imagick` extension as a requirement in the `composer.json` file.

If the `imagick` extension isn't enabled or installed, the composer will ask you to install it first with the new installation modification. This should prevent issues like #88 from happening again.

Please let me know for any clarification.