### PR TITLE
fix - social login in strict mode

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -22,7 +22,7 @@ class User extends Authenticatable implements MustVerifyEmail
     use HasSocialProviders, Notifiable;
 
     protected $fillable = [
-        'name', 'email', 'password', 'two_factor_secret', 'two_factor_recovery_codes', 'two_factor_confirmed_at',
+        'name', 'email', 'password', 'two_factor_secret', 'two_factor_recovery_codes', 'two_factor_confirmed_at', 'email_verified_at'
     ];
 
     public function hasVerifiedEmail()


### PR DESCRIPTION
when creating user using social login there is an error when using Model::shouldBeStrict due to email_verified_at is not present in fillable array.