### PR TITLE
fix test "registers a new user with password confirmation and logs in"

### DIFF
--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -89,6 +89,7 @@ it('registers a new user with password confirmation and logs in', function () {
         ->set('email', 'user@example.com')
         ->set('password', 'secret1234')
         ->set('password_confirmation', 'secret1234')
+        ->set('name', 'John Doe')
         ->call('register')
         ->assertHasNoErrors()
         ->assertRedirect('/');


### PR DESCRIPTION
If the setting `registration_include_name_field` => `true`, then this test fails with:

```
Component has errors: "name"
Failed asserting that false is true.
at vendor/livewire/livewire/src/Features/SupportValidation/TestsValidation.php:109
at tests/Feature/AuthenticationTest.php:94
```

Just adding `name` as in the other existing registration test in this same file.