### PR TITLE
Add option to check account availability before login

### DIFF
--- a/config/devdojo/auth/descriptions.php
+++ b/config/devdojo/auth/descriptions.php
@@ -16,5 +16,6 @@ return [
         'login_show_social_providers' => 'Show the social providers login buttons on the login form',
         'center_align_social_provider_button_content' => 'Center align the content in the social provider button?',
         'social_providers_location' => 'The location of the social provider buttons (top or bottom)',
+        'check_account_exists_before_login' => 'Determines if the system checks for account existence before login',
     ],
 ];

--- a/config/devdojo/auth/language.php
+++ b/config/devdojo/auth/language.php
@@ -18,6 +18,7 @@ return [
         'sign_up' => 'Sign up',
         'social_auth_authenticated_message' => 'You have been authenticated via __social_providers_list__. Please login to that network below.',
         'change_email' => 'Change Email',
+        'couldnt_find_your_account' => "Couldn’t find your Account",
     ],
     'register' => [
         'page_title' => 'Sign up',

--- a/config/devdojo/auth/settings.php
+++ b/config/devdojo/auth/settings.php
@@ -15,4 +15,5 @@ return [
     'login_show_social_providers' => true,
     'center_align_social_provider_button_content' => false,
     'social_providers_location' => 'bottom',
+    'check_account_exists_before_login' => false,
 ];

--- a/public/auth
+++ b/public/auth
@@ -1,0 +1,1 @@
+../packages/devdojo/auth/public

--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -46,7 +46,7 @@ new class extends Component
             $this->showPasswordField = false;
             return;
         }
-        
+
         $this->showIdentifierInput = true;
         $this->showSocialProviderInfo = false;
     }
@@ -69,6 +69,13 @@ new class extends Component
                     return;
                 }
             }
+
+            if(config('devdojo.auth.settings.check_account_exists_before_login') && is_null($userTryingToValidate)){
+                $this->js("setTimeout(function(){ window.dispatchEvent(new CustomEvent('focus-email', {})); }, 10);");
+                $this->addError('email', trans(config('devdojo.auth.language.login.couldnt_find_your_account')));
+                return;
+            }
+
             $this->showPasswordField = true;
             $this->js("setTimeout(function(){ window.dispatchEvent(new CustomEvent('focus-password', {})); }, 10);");
             return;
@@ -104,7 +111,7 @@ new class extends Component
                 $this->addError('password', trans('auth.failed'));
                 return;
             }
-            
+
             event(new Login(auth()->guard('web'), $this->userModel->where('email', $this->email)->first(), true));
 
             if(session()->get('url.intended') != route('logout.get')){
@@ -122,7 +129,7 @@ new class extends Component
 ?>
 
 <x-auth::layouts.app title="{{ config('devdojo.auth.language.login.page_title') }}">
-    
+
     @volt('auth.login')
         <x-auth::elements.container>
 
@@ -138,7 +145,6 @@ new class extends Component
             @endif
 
             <form wire:submit="authenticate" class="space-y-5">
-
                 @if($showPasswordField)
                     <x-auth::elements.input-placeholder value="{{ $email }}">
                         <button type="button" data-auth="edit-email-button" wire:click="editIdentity" class="font-medium text-blue-500">{{ config('devdojo.auth.language.login.edit') }}</button>
@@ -187,5 +193,5 @@ new class extends Component
 
         </x-auth::elements.container>
     @endvolt
-    
+
 </x-auth::layouts.app>


### PR DESCRIPTION
This feature introduces an option that allows the system to verify the existence of a user account before proceeding with the login process. The primary goal is to enhance security and user experience by ensuring that only existing accounts can attempt to log in.

### Key Changes:
- **New Configuration Option**: `check_account_exists_before_login`
  - This option can be enabled or disabled to control whether the system verifies account availability during the login process.
  
- **Error Handling**: 
  - If the account is not found, a message saying "Couldn’t find your account" will be displayed to the user.

### Benefits:
- **Enhanced Security**: Prevents login attempts with non-existent accounts.
- **Improved User Feedback**: Provides clear feedback when an account is not found.
  
This feature provides flexibility for applications that require pre-login account validation and improves the overall user experience during authentication.

> **Note:** Inspired by the account verification flow in Google login. 😉
