### PR TITLE
Magick exclude

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": "^7.4|^8.0|^8.1|^8.2",
-		"ext-imagick": "^3.4",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
         "laravel/folio": "^1.0",
         "livewire/livewire": "^3.0",

--- a/resources/views/pages/auth/register.blade.php
+++ b/resources/views/pages/auth/register.blade.php
@@ -31,8 +31,6 @@ new class extends Component
     public $showPasswordConfirmationField = false;
 
 
-
-
     public function rules()
     {
         $nameValidationRules = [];


### PR DESCRIPTION
We don't want to include the Magick extension by default. This can cause `composer install` issues if the user doesn't have the extension installed by default and is actually not installed by default with Herd.

I've added a section [to the documentation](https://devdojo.com/auth/docs/authentication-pages/#two-factor-challenge) that explains this package needs to be included when utilizing 2FA.