### PR TITLE
fix issue where social user saving fails after oauth callback

### DIFF
--- a/src/Models/SocialProviderUser.php
+++ b/src/Models/SocialProviderUser.php
@@ -11,7 +11,7 @@ class SocialProviderUser extends Model
     protected $table = 'social_provider_user';
 
     // Prevents the "returning id" default behaviour
-    protected $primaryKey = ['user_id', 'provider_slug'];
+    protected $primaryKey = 'user_id';
 
     // Prevents the auto-increment default behaviour
     public $incrementing = false;


### PR DESCRIPTION
## Greetings dojo community, thank you for this awesome project

# Issue
- Assuming this project supports laravel 11 ? I'm having an error when using social auth
- Oauth callback throws an error when saving a `SocialProviderUser`

![image](https://github.com/user-attachments/assets/9e991636-083a-4ed4-a5d4-edbfe9fb4503)

# Reproduce
1- use the Laravel installer and install a fresh latest version application (I used inertia vue stack)
2- install and configure the auth package
3- configure your social auth service (I tried both google and github)
4- try to register with provider, it will fail on the callback when creating a user

# Cause
the model `SocialProviderUser` has a custom (composite?) primaryKey attribute that is an array, see :https://github.com/thedevdojo/auth/commit/051748de94fd60364359407637a0581217515e93#diff-79bf4b0babdccd06a4491c7c0c134e34a898e01eac9be350b7430c4184ad44c1R14

this will cause this function in the laravel framework to throw a type error : https://github.com/laravel/framework/commit/92beae32b64be7c89e6df71cb1f56e42cc734b66#diff-59d24f1a8f0dd1e51ee7dffc8778133711634e928ecef4a91b63fc3851cb1579R435

array_key_exists() take a $key that must be a primitive, in this case an array is passed ['user_id', 'provider_slug'] which causes a type error:
```
array_key_exists(): Argument https://github.com/thedevdojo/auth/pull/1 ($key) must be a valid array offset type
```

# The fix
- Change  protected `$primaryKey = ['user_id', 'provider_slug'];` to  protected `$primaryKey = 'user_id';` and it will work
- I don't know tho why it's an array in the first place, I left a comment to the line owner and I didn't get a response