### PR TITLE
fix login tests and github actions workflow

### DIFF
--- a/resources/workflows/auth.yml
+++ b/resources/workflows/auth.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: '8.3'
         extensions: mbstring, xml, ctype, iconv, mysql
 
     - name: Cache Composer Packages
@@ -38,6 +38,9 @@ jobs:
     - name: Create sqlite file
       run: touch database/database.sqlite
 
+    - name: Copy .env
+        run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+        
     - name: List out .env
       run: cat .env
 
@@ -52,8 +55,8 @@ jobs:
     - name: Run the Auth Migrations
       run: php artisan migrate --path=vendor/devdojo/auth/database/migrations 
 
-    - name: Install PestPHP
-      run: composer require pestphp/pest --dev --with-all-dependencies
+    - name: Install PestPHP and Laravel Dusk
+      run: composer require pestphp/pest laravel/dusk alebatistella/duskapiconf --dev --with-all-dependencies
 
     - name: Run Tests
       run: ./vendor/bin/pest

--- a/resources/workflows/auth.yml
+++ b/resources/workflows/auth.yml
@@ -39,7 +39,7 @@ jobs:
       run: touch database/database.sqlite
 
     - name: Copy .env
-        run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+      run: php -r "file_exists('.env') || copy('.env.example', '.env');"
         
     - name: List out .env
       run: cat .env

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -28,7 +28,7 @@ it('registers a new user and logs in', function () {
         ->set('name', 'John Doe')
         ->call('register')
         ->assertHasNoErrors()
-        ->assertRedirect('/');
+        ->assertRedirect(config('devdojo.auth.settings.redirect_after_auth'));
 
     $this->assertTrue(Auth::check());
     $this->assertEquals('user@example.com', Auth::user()->email);
@@ -92,7 +92,7 @@ it('registers a new user with password confirmation and logs in', function () {
         ->set('name', 'John Doe')
         ->call('register')
         ->assertHasNoErrors()
-        ->assertRedirect('/');
+        ->assertRedirect(config('devdojo.auth.settings.redirect_after_auth'));
 
     $this->assertTrue(Auth::check());
     $this->assertEquals('user@example.com', Auth::user()->email);

--- a/tests/Feature/TwoFactorTest.php
+++ b/tests/Feature/TwoFactorTest.php
@@ -28,7 +28,7 @@ test('User logs in when two factor disabled, the login.id session should not be 
         ->set('password', 'password123')
         ->call('authenticate')
         ->assertHasNoErrors()
-        ->assertRedirect('/');
+        ->assertRedirect(config('devdojo.auth.settings.redirect_after_auth'));
 
     $this->assertTrue(! Session::has('login.id'));
 });
@@ -58,7 +58,7 @@ test('User logs in without 2FA, they should not be redirected to auth/two-factor
         ->set('password', 'password123')
         ->call('authenticate')
         ->assertHasNoErrors()
-        ->assertRedirect('/');
+        ->assertRedirect(config('devdojo.auth.settings.redirect_after_auth'));
 });
 
 it('user cannot view two factor challenge page logging in if it\'s disabled', function () {


### PR DESCRIPTION
1. Fixed the following tests:

- registers a new user and logs in
- registers a new user with password confirmation and logs in
- User logs in when two factor disabled, the login.id session should not be created
- User logs in without 2FA, they should not be redirected to auth/two-factor-challenge page
- Replaced: `->assertRedirect('/');` with: `->assertRedirect(config('devdojo.auth.settings.redirect_after_auth'));` This accounts for when a user has set a custom `redirect_after_auth` value.

2. Add check for copying existing`.env` or `.env.example` file before listing it (in case the `.env` does not exist.

3. Add Dusk and DuskApiConfig to PestPHP install step, otherwise the tests fail because they have not been installed.
4. Update `checkout` version to 4 (v2 will be depecrated soon)
5. Update php version to `8.3`
