### PR TITLE
Allow users to disable registrations

### DIFF
--- a/config/devdojo/auth/descriptions.php
+++ b/config/devdojo/auth/descriptions.php
@@ -17,7 +17,7 @@ return [
         'enable_email_registration' => 'Enable the ability for users to register via email',
         'login_show_social_providers' => 'Show the social providers login buttons on the login form',
         'center_align_social_provider_button_content' => 'Center align the content in the social provider button?',
-        'center_align_container_text' => 'Center align the text in the container?',
+        'center_align_text' => 'Center align text?',
         'social_providers_location' => 'The location of the social provider buttons (top or bottom)',
         'check_account_exists_before_login' => 'Determines if the system checks for account existence before login',
     ],

--- a/config/devdojo/auth/descriptions.php
+++ b/config/devdojo/auth/descriptions.php
@@ -14,6 +14,7 @@ return [
         'enable_branding' => 'This will toggle on/off the Auth branding at the bottom of each auth screen. Consider leaving on to support and help grow this project.',
         'dev_mode' => 'This is for development mode, when set in Dev Mode Assets will be loaded from Vite',
         'enable_2fa' => 'Enable the ability for users to turn on Two Factor Authentication',
+        'enable_email_registration' => 'Enable the ability for users to register via email',
         'login_show_social_providers' => 'Show the social providers login buttons on the login form',
         'center_align_social_provider_button_content' => 'Center align the content in the social provider button?',
         'social_providers_location' => 'The location of the social provider buttons (top or bottom)',

--- a/config/devdojo/auth/descriptions.php
+++ b/config/devdojo/auth/descriptions.php
@@ -17,6 +17,7 @@ return [
         'enable_email_registration' => 'Enable the ability for users to register via email',
         'login_show_social_providers' => 'Show the social providers login buttons on the login form',
         'center_align_social_provider_button_content' => 'Center align the content in the social provider button?',
+        'center_align_container_text' => 'Center align the text in the container?',
         'social_providers_location' => 'The location of the social provider buttons (top or bottom)',
         'check_account_exists_before_login' => 'Determines if the system checks for account existence before login',
     ],

--- a/config/devdojo/auth/descriptions.php
+++ b/config/devdojo/auth/descriptions.php
@@ -6,6 +6,7 @@
 return [
     'settings' => [
         'redirect_after_auth' => 'Where should the user be redirected to after they are authenticated?',
+        'registration_enabled' => 'Enable or disable registration functionality. If disabled, users will not be able to register for an account.',
         'registration_show_password_same_screen' => 'During registrations, show the password on the same screen or show it on an individual screen.',
         'registration_include_name_field' => 'During registration, include the Name field.',
         'registration_include_password_confirmation_field' => 'During registration, include the Password Confirmation field.',

--- a/config/devdojo/auth/language.php
+++ b/config/devdojo/auth/language.php
@@ -33,6 +33,7 @@ return [
         'already_have_an_account' => 'Already have an account?',
         'sign_in' => 'Sign in',
         'button' => 'Continue',
+        'email_registration_disabled' => 'Email registration is currently disabled. Please use social login.',
     ],
     'verify' => [
         'page_title' => 'Verify Your Account',

--- a/config/devdojo/auth/settings.php
+++ b/config/devdojo/auth/settings.php
@@ -13,6 +13,7 @@ return [
     'enable_branding' => true,
     'dev_mode' => false,
     'enable_2fa' => false, // Enable or disable 2FA functionality globally
+    'enable_email_registration' => true,
     'login_show_social_providers' => true,
     'center_align_social_provider_button_content' => false,
     'social_providers_location' => 'bottom',

--- a/config/devdojo/auth/settings.php
+++ b/config/devdojo/auth/settings.php
@@ -16,6 +16,7 @@ return [
     'enable_email_registration' => true,
     'login_show_social_providers' => true,
     'center_align_social_provider_button_content' => false,
+    'center_align_container_text' => false,
     'social_providers_location' => 'bottom',
     'check_account_exists_before_login' => false,
 ];

--- a/config/devdojo/auth/settings.php
+++ b/config/devdojo/auth/settings.php
@@ -5,6 +5,7 @@
  */
 return [
     'redirect_after_auth' => '/',
+    'registration_enabled' => true,
     'registration_show_password_same_screen' => true,
     'registration_include_name_field' => false,
     'registration_include_password_confirmation_field' => false,

--- a/config/devdojo/auth/settings.php
+++ b/config/devdojo/auth/settings.php
@@ -16,7 +16,7 @@ return [
     'enable_email_registration' => true,
     'login_show_social_providers' => true,
     'center_align_social_provider_button_content' => false,
-    'center_align_container_text' => false,
+    'center_align_text' => false,
     'social_providers_location' => 'bottom',
     'check_account_exists_before_login' => false,
 ];

--- a/resources/views/components/elements/container.blade.php
+++ b/resources/views/components/elements/container.blade.php
@@ -13,7 +13,7 @@
 @endphp
 
 <div id="auth-container-parent" class="relative w-full sm:max-w-md {{ $containerParentClasses }}">
-    <div id="auth-container" class="flex relative top-0 z-20 flex-col justify-center @if(config('devdojo.auth.settings.center_align_container_text'){{ 'items-center' }}@else{{ 'items-stretch' }}@endif px-10 py-8 w-full h-screen bg-white border-gray-200 sm:top-auto sm:h-full {{ $containerClasses }}">
+    <div id="auth-container" class="flex relative top-0 z-20 flex-col justify-center @if(config('devdojo.auth.settings.center_align_container_text')){{ 'items-center' }}@else{{ 'items-stretch' }}@endif px-10 py-8 w-full h-screen bg-white border-gray-200 sm:top-auto sm:h-full {{ $containerClasses }}">
         {{ $slot }}
     </div>
 </div>

--- a/resources/views/components/elements/container.blade.php
+++ b/resources/views/components/elements/container.blade.php
@@ -13,7 +13,7 @@
 @endphp
 
 <div id="auth-container-parent" class="relative w-full sm:max-w-md {{ $containerParentClasses }}">
-    <div id="auth-container" class="flex relative top-0 z-20 flex-col justify-center items-stretch px-10 py-8 w-full h-screen bg-white border-gray-200 sm:top-auto sm:h-full {{ $containerClasses }}">
+    <div id="auth-container" class="flex relative top-0 z-20 flex-col justify-center @if(config('devdojo.auth.settings.center_align_container_text'){{ 'items-center' }}@else{{ 'items-stretch' }}@endif px-10 py-8 w-full h-screen bg-white border-gray-200 sm:top-auto sm:h-full {{ $containerClasses }}">
         {{ $slot }}
     </div>
 </div>

--- a/resources/views/components/elements/container.blade.php
+++ b/resources/views/components/elements/container.blade.php
@@ -13,7 +13,7 @@
 @endphp
 
 <div id="auth-container-parent" class="relative w-full sm:max-w-md {{ $containerParentClasses }}">
-    <div id="auth-container" class="flex relative top-0 z-20 flex-col justify-center @if(config('devdojo.auth.settings.center_align_container_text')){{ 'items-center' }}@else{{ 'items-stretch' }}@endif px-10 py-8 w-full h-screen bg-white border-gray-200 sm:top-auto sm:h-full {{ $containerClasses }}">
+    <div id="auth-container" class="flex relative top-0 z-20 flex-col justify-center items-stretch px-10 py-8 w-full h-screen bg-white border-gray-200 sm:top-auto sm:h-full {{ $containerClasses }}">
         {{ $slot }}
     </div>
 </div>

--- a/resources/views/components/elements/social-providers.blade.php
+++ b/resources/views/components/elements/social-providers.blade.php
@@ -7,7 +7,7 @@
     @if($separator && config('devdojo.auth.settings.social_providers_location') != 'top')
         <x-auth::elements.separator class="my-6">{{ $separator_text }}</x-auth::elements.separator>
     @endif
-    <div class="relative space-y-2 w-full">
+    <div class="relative space-y-2 w-full @if(config('devdojo.auth.settings.social_providers_location') != 'top' && !$separator){{ 'mt-3' }}@endif">
         @foreach($socialProviders as $slug => $provider)
             <x-auth::elements.social-button :$slug :$provider />
         @endforeach

--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -188,10 +188,12 @@ new class extends Component
             </form>
 
 
-            <div class="mt-3 space-x-0.5 text-sm leading-5 text-left" style="color:{{ config('devdojo.auth.appearance.color.text') }}">
-                <span class="opacity-[47%]"> {{ config('devdojo.auth.language.login.dont_have_an_account') }} </span>
-                <x-auth::elements.text-link data-auth="register-link" href="{{ route('auth.register') }}">{{ config('devdojo.auth.language.login.sign_up') }}</x-auth::elements.text-link>
-            </div>
+            @if(config('devdojo.auth.settings.registration_enabled'))
+                <div class="mt-3 space-x-0.5 text-sm leading-5 text-left" style="color:{{ config('devdojo.auth.appearance.color.text') }}">
+                    <span class="opacity-[47%]"> {{ config('devdojo.auth.language.login.dont_have_an_account') }} </span>
+                    <x-auth::elements.text-link data-auth="register-link" href="{{ route('auth.register') }}">{{ config('devdojo.auth.language.login.sign_up') }}</x-auth::elements.text-link>
+                </div>
+            @endif
 
             @if(config('devdojo.auth.settings.login_show_social_providers') && config('devdojo.auth.settings.social_providers_location') != 'top')
                 <x-auth::elements.social-providers />

--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -188,7 +188,7 @@ new class extends Component
             </form>
 
 
-            @if(config('devdojo.auth.settings.registration_enabled'))
+            @if(config('devdojo.auth.settings.registration_enabled', true))
                 <div class="mt-3 space-x-0.5 text-sm leading-5 text-left" style="color:{{ config('devdojo.auth.appearance.color.text') }}">
                     <span class="opacity-[47%]"> {{ config('devdojo.auth.language.login.dont_have_an_account') }} </span>
                     <x-auth::elements.text-link data-auth="register-link" href="{{ route('auth.register') }}">{{ config('devdojo.auth.language.login.sign_up') }}</x-auth::elements.text-link>

--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -189,7 +189,7 @@ new class extends Component
 
 
             @if(config('devdojo.auth.settings.registration_enabled', true))
-                <div class="mt-3 space-x-0.5 text-sm leading-5 text-left" style="color:{{ config('devdojo.auth.appearance.color.text') }}">
+                <div class="mt-3 space-x-0.5 text-sm leading-5 @if(config('devdojo.auth.settings.center_align_text')){{ 'text-center' }}@else{{ 'text-left' }}@endif" style="color:{{ config('devdojo.auth.appearance.color.text') }}">
                     <span class="opacity-[47%]"> {{ config('devdojo.auth.language.login.dont_have_an_account') }} </span>
                     <x-auth::elements.text-link data-auth="register-link" href="{{ route('auth.register') }}">{{ config('devdojo.auth.language.login.sign_up') }}</x-auth::elements.text-link>
                 </div>

--- a/resources/views/pages/auth/register.blade.php
+++ b/resources/views/pages/auth/register.blade.php
@@ -184,7 +184,7 @@ new class extends Component
         </form>
         @endif
 
-        <div class="@if(config('devdojo.auth.settings.social_providers_location') != 'top' && $showEmailRegistration){{ 'mt-3' }}@endif space-x-0.5 text-sm leading-5 text-left" style="color:{{ config('devdojo.auth.appearance.color.text') }}">
+        <div class="@if(config('devdojo.auth.settings.social_providers_location') != 'top' && $showEmailRegistration){{ 'mt-3' }}@endif space-x-0.5 text-sm leading-5 @if(config('devdojo.auth.settings.center_align_text')){{ 'text-center' }}@else{{ 'text-left' }}@endif" style="color:{{ config('devdojo.auth.appearance.color.text') }}">
             <span class="opacity-[47%]">{{config('devdojo.auth.language.register.already_have_an_account')}}</span>
             <x-auth::elements.text-link data-auth="login-link" href="{{ route('auth.login') }}">{{config('devdojo.auth.language.register.sign_in')}}</x-auth::elements.text-link>
         </div>

--- a/resources/views/pages/auth/register.blade.php
+++ b/resources/views/pages/auth/register.blade.php
@@ -184,7 +184,7 @@ new class extends Component
         </form>
         @endif
 
-        <div class="mt-3 space-x-0.5 text-sm leading-5 text-left" style="color:{{ config('devdojo.auth.appearance.color.text') }}">
+        <div class="@if(config('devdojo.auth.settings.social_providers_location') != 'top' && $showEmailRegistration){{ 'mt-3' }}@endif space-x-0.5 text-sm leading-5 text-left" style="color:{{ config('devdojo.auth.appearance.color.text') }}">
             <span class="opacity-[47%]">{{config('devdojo.auth.language.register.already_have_an_account')}}</span>
             <x-auth::elements.text-link data-auth="login-link" href="{{ route('auth.login') }}">{{config('devdojo.auth.language.register.sign_in')}}</x-auth::elements.text-link>
         </div>

--- a/resources/views/pages/auth/register.blade.php
+++ b/resources/views/pages/auth/register.blade.php
@@ -29,10 +29,14 @@ new class extends Component
     public $showEmailField = true;
     public $showPasswordField = false;
     public $showPasswordConfirmationField = false;
-
+    public $showEmailRegistration = true;
 
     public function rules()
     {
+        if (!$this->settings->enable_email_registration) {
+            return [];
+        }
+
         $nameValidationRules = [];
         if (config('devdojo.auth.settings.registration_include_name_field')) {
             $nameValidationRules = ['name' => 'required'];
@@ -59,6 +63,15 @@ new class extends Component
             return;
         }
 
+        if (!$this->settings->enable_email_registration) {
+            $this->showEmailRegistration = false;
+            $this->showNameField = false;
+            $this->showEmailField = false;
+            $this->showPasswordField = false;
+            $this->showPasswordConfirmationField = false;
+            return;
+        }
+
         if ($this->settings->registration_include_name_field) {
             $this->showNameField = true;
         }
@@ -77,6 +90,11 @@ new class extends Component
         if (!$this->settings->registration_enabled) {
             session()->flash('error', config('devdojo.auth.language.register.registrations_disabled', 'Registrations are currently disabled.'));
             return redirect()->route('auth.login');
+        }
+
+        if (!$this->settings->enable_email_registration) {
+            session()->flash('error', config('devdojo.auth.language.register.email_registration_disabled', 'Email registration is currently disabled. Please use social login.'));
+            return;
         }
 
         if (!$this->showPasswordField) {
@@ -140,6 +158,7 @@ new class extends Component
         <x-auth::elements.social-providers />
         @endif
 
+        @if($showEmailRegistration)
         <form wire:submit="register" class="space-y-5">
 
             @if($showNameField)
@@ -163,6 +182,7 @@ new class extends Component
 
             <x-auth::elements.button data-auth="submit-button" rounded="md" submit="true">{{config('devdojo.auth.language.register.button')}}</x-auth::elements.button>
         </form>
+        @endif
 
         <div class="mt-3 space-x-0.5 text-sm leading-5 text-left" style="color:{{ config('devdojo.auth.appearance.color.text') }}">
             <span class="opacity-[47%]">{{config('devdojo.auth.language.register.already_have_an_account')}}</span>

--- a/resources/views/pages/auth/register.blade.php
+++ b/resources/views/pages/auth/register.blade.php
@@ -53,6 +53,12 @@ new class extends Component
     {
         $this->loadConfigs();
 
+        if (!$this->settings->registration_enabled) {
+            session()->flash('error', config('devdojo.auth.language.register.registrations_disabled', 'Registrations are currently disabled.'));
+            redirect()->route('auth.login');
+            return;
+        }
+
         if ($this->settings->registration_include_name_field) {
             $this->showNameField = true;
         }
@@ -68,6 +74,11 @@ new class extends Component
 
     public function register()
     {
+        if (!$this->settings->registration_enabled) {
+            session()->flash('error', config('devdojo.auth.language.register.registrations_disabled', 'Registrations are currently disabled.'));
+            return redirect()->route('auth.login');
+        }
+
         if (!$this->showPasswordField) {
             if ($this->settings->registration_include_name_field) {
                 $this->validateOnly('name');

--- a/resources/views/pages/auth/register.blade.php
+++ b/resources/views/pages/auth/register.blade.php
@@ -155,7 +155,7 @@ new class extends Component
         <x-auth::elements.session-message />
 
         @if(config('devdojo.auth.settings.social_providers_location') == 'top')
-        <x-auth::elements.social-providers />
+            <x-auth::elements.social-providers :separator="$showEmailRegistration" />
         @endif
 
         @if($showEmailRegistration)
@@ -190,7 +190,7 @@ new class extends Component
         </div>
 
         @if(config('devdojo.auth.settings.social_providers_location') != 'top')
-        <x-auth::elements.social-providers />
+            <x-auth::elements.social-providers :separator="$showEmailRegistration" />
         @endif
 
 

--- a/resources/views/pages/auth/register.blade.php
+++ b/resources/views/pages/auth/register.blade.php
@@ -94,7 +94,7 @@ new class extends Component
 
         if (!$this->settings->enable_email_registration) {
             session()->flash('error', config('devdojo.auth.language.register.email_registration_disabled', 'Email registration is currently disabled. Please use social login.'));
-            return;
+            return redirect()->route('auth.register');
         }
 
         if (!$this->showPasswordField) {

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Auth;
 
 beforeEach(function () {
     config()->set('devdojo.auth.settings.registration_enabled', true);
+    config()->set('devdojo.auth.settings.enable_email_registration', true);
 });
 
 it('allows access to registration page when enabled', function () {
@@ -42,4 +43,53 @@ it('preserves other registration settings when enabled', function () {
 
     expect($component->get('showNameField'))->toBeTrue();
     expect($component->get('showPasswordField'))->toBeTrue();
+});
+
+it('hides email registration form when email registration is disabled', function () {
+    config()->set('devdojo.auth.settings.enable_email_registration', false);
+
+    $component = Livewire::test('auth.register');
+
+    expect($component->get('showEmailRegistration'))->toBeFalse();
+    expect($component->get('showEmailField'))->toBeFalse();
+    expect($component->get('showPasswordField'))->toBeFalse();
+    expect($component->get('showNameField'))->toBeFalse();
+});
+
+it('shows email registration form when email registration is enabled', function () {
+    config()->set('devdojo.auth.settings.enable_email_registration', true);
+
+    $component = Livewire::test('auth.register');
+
+    expect($component->get('showEmailRegistration'))->toBeTrue();
+    expect($component->get('showEmailField'))->toBeTrue();
+});
+
+it('prevents email registration when disabled', function () {
+    config()->set('devdojo.auth.settings.enable_email_registration', false);
+
+    $component = Livewire::test('auth.register')
+        ->set('email', 'test@example.com')
+        ->set('password', 'password123')
+        ->call('register');
+
+    expect(Auth::check())->toBeFalse();
+    expect(session('error'))->toBe(
+        config('devdojo.auth.language.register.email_registration_disabled', 'Email registration is currently disabled. Please use social login.')
+    );
+});
+
+it('validates empty rules when email registration is disabled', function () {
+    config()->set('devdojo.auth.settings.enable_email_registration', false);
+
+    $component = Livewire::test('auth.register');
+
+    expect($component->instance()->rules())->toBeEmpty();
+});
+
+it('preserves social login functionality when email registration is disabled', function () {
+    config()->set('devdojo.auth.settings.enable_email_registration', false);
+
+    Livewire::test('auth.register')
+        ->assertSee('social-providers');
 });

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -90,6 +90,11 @@ it('validates empty rules when email registration is disabled', function () {
 it('preserves social login functionality when email registration is disabled', function () {
     config()->set('devdojo.auth.settings.enable_email_registration', false);
 
+    config()->set('devdojo.auth.providers', [
+        'google' => ['name' => 'Google', 'active' => true],
+        'facebook' => ['name' => 'Facebook', 'active' => false],
+    ]);
+
     Livewire::test('auth.register')
-        ->assertSee('social-providers');
+        ->assertSee('Google');
 });

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Support\Facades\Auth;
+
+beforeEach(function () {
+    config()->set('devdojo.auth.settings.registration_enabled', true);
+});
+
+it('allows access to registration page when enabled', function () {
+    Livewire::test('auth.register')
+        ->assertOk()
+        ->assertDontSee('Registrations are currently disabled');
+});
+
+it('redirects to login when registrations are disabled', function () {
+    config()->set('devdojo.auth.settings.registration_enabled', false);
+
+    Livewire::test('auth.register')
+        ->assertRedirect(route('auth.login'));
+
+    expect(session('error'))->toBe(
+        config('devdojo.auth.language.register.registrations_disabled', 'Registrations are currently disabled.')
+    );
+});
+
+it('allows registration when enabled', function () {
+    $component = Livewire::test('auth.register')
+        ->set('email', 'test@example.com')
+        ->set('password', 'password123')
+        ->set('name', 'Test User')
+        ->call('register');
+
+    expect(Auth::check())->toBeTrue();
+    expect(Auth::user()->email)->toBe('test@example.com');
+});
+
+it('preserves other registration settings when enabled', function () {
+    config()->set('devdojo.auth.settings.registration_include_name_field', true);
+    config()->set('devdojo.auth.settings.registration_show_password_same_screen', true);
+
+    $component = Livewire::test('auth.register');
+
+    expect($component->get('showNameField'))->toBeTrue();
+    expect($component->get('showPasswordField'))->toBeTrue();
+});


### PR DESCRIPTION
As per a few user requests on the DevDojo site:

> https://devdojo.com/question/auth-package-option-to-disable-registration
> https://devdojo.com/question/how-to-diable-registration-feature-using-filamentphp-and-auth-package

Implementing that functionality. When disabled if someone visits the register route they will be redirected to the `/login` route and see the following message:

<img width="524" alt="image" src="https://github.com/user-attachments/assets/03ba24eb-e778-4f7c-b6fa-395749e05184">

