### PR TITLE
Allow autocompletion for email and password inputs

### DIFF
--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -156,7 +156,7 @@ new class extends Component
                     </x-auth::elements.input-placeholder>
                 @else
                     @if($showIdentifierInput)
-                        <x-auth::elements.input :label="config('devdojo.auth.language.login.email_address')" type="email" wire:model="email" autofocus="true" data-auth="email-input" id="email" required />
+                        <x-auth::elements.input :label="config('devdojo.auth.language.login.email_address')" type="email" wire:model="email" autofocus="true" data-auth="email-input" id="email" name="email" autocomplete="email" required />
                     @endif
                 @endif
 
@@ -174,13 +174,17 @@ new class extends Component
                     @endif
                 @endif
 
-                @if($showPasswordField)
-                    <x-auth::elements.input :label="config('devdojo.auth.language.login.password')" type="password" wire:model="password" id="password" data-auth="password-input" />
-					<x-auth::elements.checkbox :label="config('devdojo.auth.language.login.remember_me')" wire:model="rememberMe" id="remember-me" data-auth="remember-me-input" />
-					<div class="flex items-center justify-between mt-6 text-sm leading-5">
+                @php
+                    $passwordFieldClasses = $showPasswordField ? 'flex flex-col gap-6' : 'hidden';
+                @endphp
+
+                <div class="{{ $passwordFieldClasses }}">
+                    <x-auth::elements.input :label="config('devdojo.auth.language.login.password')" type="password" wire:model="password" data-auth="password-input" id="password" name="password" autocomplete="current-password" />
+                    <x-auth::elements.checkbox :label="config('devdojo.auth.language.login.remember_me')" wire:model="rememberMe" id="remember-me" data-auth="remember-me-input" />
+                    <div class="flex items-center justify-between text-sm leading-5">
                         <x-auth::elements.text-link href="{{ route('auth.password.request') }}" data-auth="forgot-password-link">{{ config('devdojo.auth.language.login.forget_password') }}</x-auth::elements.text-link>
                     </div>
-                @endif
+                </div>
 
                 <x-auth::elements.button type="primary" data-auth="submit-button" rounded="md" size="md" submit="true">
                     {{ config('devdojo.auth.language.login.button') }}

--- a/resources/views/pages/auth/password/[token].blade.php
+++ b/resources/views/pages/auth/password/[token].blade.php
@@ -77,8 +77,8 @@ new class extends Component
 
             <form wire:submit="resetPassword" class="space-y-5">
                 <x-auth::elements.input :label="config('devdojo.auth.language.passwordReset.email')" type="email" id="email" name="email" data-auth="email-input" wire:model="email" autofocus="true" />
-                <x-auth::elements.input :label="config('devdojo.auth.language.passwordReset.password')" type="password" id="password" name="password" data-auth="password-input" wire:model="password" />
-                <x-auth::elements.input :label="config('devdojo.auth.language.passwordReset.password_confirm')" type="password" id="password_confirmation" name="password_confirmation" data-auth="password-confirm-input" wire:model="passwordConfirmation" />
+                <x-auth::elements.input :label="config('devdojo.auth.language.passwordReset.password')" type="password" id="password" name="password" data-auth="password-input" wire:model="password" autocomplete="new-password" />
+                <x-auth::elements.input :label="config('devdojo.auth.language.passwordReset.password_confirm')" type="password" id="password_confirmation" name="password_confirmation" data-auth="password-confirm-input" wire:model="passwordConfirmation" autocomplete="new-password" />
                 <x-auth::elements.button type="primary" data-auth="submit-button" rounded="md" submit="true">{{config('devdojo.auth.language.passwordReset.button')}}</x-auth::elements.button>
             </form>
         </x-auth::elements.container>

--- a/resources/views/pages/auth/password/confirm.blade.php
+++ b/resources/views/pages/auth/password/confirm.blade.php
@@ -44,7 +44,7 @@ new class extends Component
                 :show_subheadline="($language->passwordConfirm->show_subheadline ?? false)"
             />
             <form wire:submit="confirm" class="space-y-5">
-                <x-auth::elements.input :label="config('devdojo.auth.language.passwordConfirm.password')" type="password" id="password" name="password" data-auth="password-input" autofocus="true" wire:model="password" />
+                <x-auth::elements.input :label="config('devdojo.auth.language.passwordConfirm.password')" type="password" id="password" name="password" data-auth="password-input" autofocus="true" wire:model="password" autocomplete="current-password" />
                 <x-auth::elements.button type="primary" rounded="md" data-auth="submit-button" submit="true">{{config('devdojo.auth.language.passwordConfirm.button')}}</x-auth::elements.button>
             </form>
         </x-auth::elements.container>

--- a/resources/views/pages/auth/password/reset.blade.php
+++ b/resources/views/pages/auth/password/reset.blade.php
@@ -67,7 +67,7 @@ new class extends Component
             </div>
         @else
             <form wire:submit="sendResetPasswordLink" class="space-y-5">
-                <x-auth::elements.input :label="config('devdojo.auth.language.passwordResetRequest.email')" type="email" id="email" name="email" data-auth="email-input" wire:model="email" autofocus="true" />
+                <x-auth::elements.input :label="config('devdojo.auth.language.passwordResetRequest.email')" type="email" id="email" name="email" data-auth="email-input" wire:model="email" autofocus="true" autocomplete="email" />
                 <x-auth::elements.button type="primary" data-auth="submit-button" rounded="md" submit="true">{{config('devdojo.auth.language.passwordResetRequest.button')}}</x-auth::elements.button>
             </form>
         @endif

--- a/resources/views/pages/auth/register.blade.php
+++ b/resources/views/pages/auth/register.blade.php
@@ -139,15 +139,15 @@ new class extends Component
             @php
             $autofocusEmail = ($showNameField) ? false : true;
             @endphp
-            <x-auth::elements.input :label="config('devdojo.auth.language.register.email_address')" id="email" type="email" wire:model="email" data-auth="email-input" :autofocus="$autofocusEmail" required />
+            <x-auth::elements.input :label="config('devdojo.auth.language.register.email_address')" id="email" name="email" type="email" wire:model="email" data-auth="email-input" :autofocus="$autofocusEmail" autocomplete="email" required />
             @endif
 
             @if($showPasswordField)
-            <x-auth::elements.input :label="config('devdojo.auth.language.register.password')" type="password" wire:model="password" id="password" data-auth="password-input" required />
+            <x-auth::elements.input :label="config('devdojo.auth.language.register.password')" type="password" wire:model="password" id="password" name="password" data-auth="password-input" autocomplete="new-password" required />
             @endif
 
             @if($showPasswordConfirmationField)
-            <x-auth::elements.input :label="config('devdojo.auth.language.register.password_confirmation')" type="password" wire:model="password_confirmation" id="password_confirmation" data-auth="password-confirmation-input" required />
+            <x-auth::elements.input :label="config('devdojo.auth.language.register.password_confirmation')" type="password" wire:model="password_confirmation" id="password_confirmation" name="password_confirmation" data-auth="password-confirmation-input" autocomplete="new-password" required />
             @endif
 
             <x-auth::elements.button data-auth="submit-button" rounded="md" submit="true">{{config('devdojo.auth.language.register.button')}}</x-auth::elements.button>


### PR DESCRIPTION
This pull request allows web browsers and password managers to autocomplete the email and password inputs:

- adding the `autocomplete` on email and password inputs
- adding the `name` property where missing (in order to provide autocompletion, user-agents might require inputs to have a name and/or id attribute)

In the login page, I've made sure that the password input is present in the DOM right from the start, because otherwise in some cases the credentials autocompletion doesn't work (for example with the Google Password Manager in Chrome).
The password input is hidden by default and I change its CSS classes to show it when required.