### PR TITLE
update linkedin provider name to the correct one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ To get a local version working of DevDojo Auth.
 
 - Create a new Laravel application
 - Create a new folder at the root called `packages`
-- Inisde the packages folder will be `devdojo/auth` where auth will be the contents of this repo
+- Inside the packages folder will be `devdojo/auth` where auth will be the contents of this repo
 - Update your composer.json to include `devdojo/auth` inside the `repositories` key, and include the package inside the `require` key. 
 
 > You'll also need to set the stability to `dev` in the composer.json

--- a/config/devdojo/auth/providers.php
+++ b/config/devdojo/auth/providers.php
@@ -23,7 +23,7 @@ return [
         'client_id' => env('TWITTER_CLIENT_ID'),
         'client_secret' => env('TWITTER_CLIENT_SECRET'),
     ],
-    'linkedin' => [
+    'linkedin-openid' => [
         'name' => 'LinkedIn',
         'scopes' => null,
         'parameters' => null,


### PR DESCRIPTION
## Description of the issue
Following the documentation of devdojo auth package, I wanted to use linkedin. But it was not working, although google worked, so my setup was correct.

## How to reproduce the error
- Follow exactly the docs and try to create a developer app in linkedin (you need a linkedin page for that, create one)
- Activate `Share on LinkedIn` and `Sign In with LinkedIn using OpenID Connect` products in the Products section on linkedin developer portal.
- Add `auth/linkedin/callback` in the Authorized redirect URLs for your app, but it will not work because the linkedin API has changed.

**Reason from what I understood**: Microsoft has deprecated the old API as of August 1, 2023!

Here some of the references:
-  https://github.com/nextauthjs/next-auth/issues/8831#issuecomment-1772315424

## How I fixed it
I read through the linkedin api, and indeed the the API was changed instead of using `"linkedin"` it's now `"linkedin-openid"`.
You need to change the callback redirect url in linkedin developers portal to `auth/linkedin-openid/callback`.

Also slack is now `"slack-openid"` although I haven't tested it, I can try and test it than update it as well.

I'm not sure about something in regards to this issue to be honest, it seems that when I activated the openid in linkedin developers (I can't disable it after), at that point it won't allow me to pass through the linkedin API with the "linkedin" provider but I need to use "linkedin-openid", but maybe If I haven't activated it, it could have worked. This issue needs to be handled so that both would work if that's the case, let me know what do you think.