### PR TITLE
fix: increase token field length for Google OAuth2 compatibility

### DIFF
--- a/database/migrations/2024_01_04_000004_update_social_provider_user_token_field_lenght.php
+++ b/database/migrations/2024_01_04_000004_update_social_provider_user_token_field_lenght.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('social_provider_user', function (Blueprint $table) {
+
+            $table->text('token')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('social_provider_user', function (Blueprint $table) {
+            $table->string('token', 191)->change();
+        });
+    }
+};


### PR DESCRIPTION
The Google OAuth2 access tokens can be up to 2048 bytes long, but the current database schema limits the token field to 191 characters. This change modifies the token field type to TEXT to accommodate longer tokens and prevent truncation issues during social authentication.

- Changes users.token field from VARCHAR(191) to TEXT
- Ensures compatibility with Google OAuth2 token length requirements
- Prevents authentication errors due to token truncation

Reference: Google OAuth2 token length documentation