### PR TITLE
Add Vapor compatibility for build scripts

### DIFF
--- a/resources/views/includes/head.blade.php
+++ b/resources/views/includes/head.blade.php
@@ -6,8 +6,8 @@
 @if(config('devdojo.auth.settings.dev_mode'))
     @vite(['packages/devdojo/auth/resources/css/auth.css', 'packages/devdojo/auth/resources/css/auth.js'])
 @else
-    <script src="/auth/build/assets/scripts.js"></script>
-    <link rel="stylesheet" href="/auth/build/assets/styles.css" />
+    <script src="{{ asset('/auth/build/assets/scripts.js') }}"></script>
+    <link rel="stylesheet" href="{{ asset('/auth/build/assets/styles.css') }}" />
 @endif
 
 @php


### PR DESCRIPTION
This pull request includes a small but important change to the `resources/views/includes/head.blade.php` file. The change ensures that asset URLs are correctly generated using the `asset` helper function instead of hardcoding the paths.

* [`resources/views/includes/head.blade.php`](diffhunk://#diff-ca35324fdce68e8db52afb8e83cf30596036659c5433401279610cfc2c61d490L9-R10): Updated the script and stylesheet URLs to use the `asset` helper function for proper URL generation.