### PR TITLE
fix(auth): prevent duplicate form submissions in 2FA code input

### DIFF
--- a/resources/views/components/elements/input-code.blade.php
+++ b/resources/views/components/elements/input-code.blade.php
@@ -9,6 +9,7 @@
     {
         total_digits: @js($digits),
         eventCallback: @js($eventCallback),
+        callbackSubmitted: false,
         moveCursorNext (index, digits, evt) {
         
             if (!isNaN(parseInt(evt.key)) && parseInt(evt.key) >= 0 && parseInt(evt.key) <= 9 && index != digits) {
@@ -54,7 +55,8 @@
 
         },
         submitCallback(){
-            if(this.eventCallback){
+            if(this.eventCallback && !this.callbackSubmitted){
+                this.callbackSubmitted = true;
                 window.dispatchEvent(new CustomEvent(this.eventCallback, { detail: { code: this.generateCode() }}));
             }
         },


### PR DESCRIPTION
## Description
This PR fixes an issue where the 2FA code input form could be submitted multiple times when using password managers like 1Password. The duplicate submissions would result in 500 errors due to invalid session state on subsequent requests.

## Changes
- Added `callbackSubmitted` state tracking to prevent multiple callback executions
- Implemented submission state check before triggering callback events