### PR TITLE
Support OAuth Scopes & Update Token Data Limits

### DIFF
--- a/database/migrations/2025_08_03_213559_change_token_to_text_on_social_provider_users_table.php
+++ b/database/migrations/2025_08_03_213559_change_token_to_text_on_social_provider_users_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('social_provider_user', function (Blueprint $table) {
+            $table->text('token')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('social_provider_user', function (Blueprint $table) {
+            $table->string('token', 400)->change();
+        });
+    }
+};

--- a/database/migrations/2025_08_03_213701_change_refresh_token_to_text_on_social_provider_users_table.php
+++ b/database/migrations/2025_08_03_213701_change_refresh_token_to_text_on_social_provider_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('social_provider_user', function (Blueprint $table) {
+            // Add a new 'refresh_token' column
+            $table->text('refresh_token')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('social_provider_user', function (Blueprint $table) {
+            $table->string('refresh_token')->change();
+        });
+    }
+};

--- a/database/migrations/2025_08_03_213701_change_refresh_token_to_text_on_social_provider_users_table.php
+++ b/database/migrations/2025_08_03_213701_change_refresh_token_to_text_on_social_provider_users_table.php
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('social_provider_user', function (Blueprint $table) {
-            // Add a new 'refresh_token' column
+            // Change refresh_token column to text type
             $table->text('refresh_token')->change();
         });
     }

--- a/src/Http/Controllers/SocialController.php
+++ b/src/Http/Controllers/SocialController.php
@@ -19,7 +19,9 @@ class SocialController
     {
         $this->dynamicallySetSocialProviderCredentials($driver);
 
-        return Socialite::driver($driver)->redirect();
+        $scopes = config('devdojo.auth.providers.'.$driver.'.scopes', []);
+
+        return Socialite::driver($driver)->scopes($scopes)->redirect();
     }
 
     private function dynamicallySetSocialProviderCredentials($provider)

--- a/src/Models/SocialProvider.php
+++ b/src/Models/SocialProvider.php
@@ -25,6 +25,11 @@ class SocialProvider extends Model
 
         foreach ($socialProviders as $key => $provider) {
             $provider['slug'] = $key;
+
+            if (isset($provider['scopes']) && is_array($provider['scopes'])) {
+                $provider['scopes'] = implode(',', $provider['scopes']);
+            }
+
             array_push($rowsArray, $provider);
         }
 


### PR DESCRIPTION
This PR fixes missing OAuth scopes during the social auth redirect and widens token columns to handle long provider tokens.

## Why

* Providers support a `scopes` setting, but we weren’t passing it on redirect. That breaks flows that need extra permissions.
* Some Socialite providers return tokens longer than 400 chars. We were truncating them.

## What changed

### Social auth

- `SocialController@redirect`: reads provider config and applies the configured scopes to the redirect.
- `SocialProvider::getRows`: if `scopes` is an array, store it as a comma-separated string.

### Database

- `token` on `social_provider_user` → `text`. Down migrates to `string(400)`.  
  [2025_08_03_213559_change_token_to_text_on_social_provider_users_table.php](diffhunk://#diff-9640701a65beabf39a2d94cdfbec8636c203eb71b655d2225ec4d8d4e4cf3ff1R1-R21)
- `refresh_token` on `social_provider_user` → `text`. Down migrates to `string(191|400)`.  
  [2025_08_03_213701_change_refresh_token_to_text_on_social_provider_users_table.php](diffhunk://#diff-6f95ee1b3e3e75afa66767aafb85e28db1c332ee4d4ec3f73541e8d6447b1394R1-R22)

### Controller update

- [SocialController.php](diffhunk://#diff-972a9570e672995a174d5ceff3bffbdc0ebb493c81025ecae28ac7b3ef41e202L22-R24)

### Model update

- [SocialProvider.php](diffhunk://#diff-985681efb61c2ba655c796c5a00c3a3d1c11194be5b7ccf757042e0d286ac562R28-R32)


## Config example

```php
// config/services.php
'vatsim' => [
    'name' => 'VATSIM',
    'scopes' => ['full_name', 'email', 'vatsim_details', 'country'],
    'parameters' => null,
    'stateless' => true,
    'active' => true,
    'socialite' => false,
    'svg' => '...',
    'client_id' => env('VATSIM_CLIENT_ID'),
    'client_secret' => env('VATSIM_CLIENT_SECRET'),
]
```

## Testing

* ✅ PEST tests passing
* ⚠️ Dusk has some flaky cases from `dev-main`
* 🔄 Manual tests across multiple providers worked as expected

## Migration notes

* Run migrations after deploy.
* Rolling back will cut tokens to 400 chars. Back up if that’s a concern.
* Clear config cache if you change scopes: `php artisan config:clear`

## Impact

* No API changes.
* Existing configs with array scopes keep working. We store scopes as a comma-separated strings through Sushi.

## Reason for the PR
I opened this for DevDojo Auth because `scopes` existed in provider setup, but the redirect ignored them. This applies the scopes and prevents token truncation seen with some custom Socialite providers.