### PR TITLE
Remove Login event trigger from login process

### DIFF
--- a/resources/views/pages/auth/login.blade.php
+++ b/resources/views/pages/auth/login.blade.php
@@ -124,8 +124,6 @@ new class extends Component
                 return;
             }
 
-            event(new Login(auth()->guard('web'), $this->userModel->where('email', $this->email)->first(), true));
-
             if(session()->get('url.intended') != route('logout.get')){
                 session()->regenerate();
                 redirect()->intended(config('devdojo.auth.settings.redirect_after_auth'));


### PR DESCRIPTION
Removed the event triggering for the Login event. When adding a listener for `Illuminate\Auth\Events\Login` event listener, the login event is triggered twice. Removing this line makes sure it only registers once. I'm not sure where the other event is being triggered, but it seems like this one is unnecessary. 