### PR TITLE
ci: Add PHP 8.5 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["8.2", "8.3", "8.4"]
+        php-version: ["8.2", "8.3", "8.4", "8.5"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds PHP 8.5 to the CI test matrix for early compatibility testing.

