### PR TITLE
ci: Add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "php"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(deps):"


### PR DESCRIPTION
Adds Dependabot configuration to automatically keep dependencies up to date.

**Ecosystems configured:**
- `composer` — PHP dependencies, weekly on Mondays
- `npm` — JavaScript dependencies, weekly on Mondays
- `github-actions` — CI action versions, monthly

**Settings:**
- Max 5 open PRs for composer/npm, 3 for GitHub Actions
- Labeled by dependency type for easy filtering
- Conventional commit prefixes (`chore(deps):`)