### PR TITLE
fix: Block social sign-on registration when registrations are disabled

### DIFF
--- a/src/Http/Controllers/SocialController.php
+++ b/src/Http/Controllers/SocialController.php
@@ -77,6 +77,12 @@ class SocialController
 
         $user = app(config('auth.providers.users.model'))->where('email', $socialiteUser->getEmail())->first();
 
+        // If no existing user and registrations are disabled, reject the request
+        if (! $user && ! config('devdojo.auth.settings.registration_enabled', true)) {
+            return redirect()->route('auth.login')->with('error',
+                config('devdojo.auth.language.register.registrations_disabled', 'Registrations are currently disabled.'));
+        }
+
         if ($user) {
             $existingProvider = $user->socialProviders()->first();
             if ($existingProvider) {


### PR DESCRIPTION
## Problem

When `registration_enabled` is set to `false` in the auth settings, new users could still create accounts by signing in with a social provider (Google, Facebook, etc.). This bypassed the registration restriction.

## Solution

Added a check in `SocialController::findOrCreateProviderUser()` that:
- Rejects new user creation when registrations are disabled
- Redirects to login with the appropriate error message
- Still allows **existing users** to log in via social providers

## Changes

- `src/Http/Controllers/SocialController.php` - Added registration check before creating new users

## Testing

- All 44 existing tests pass
- Existing users can still log in via social when registration is disabled
- New users are blocked from creating accounts via social when registration is disabled