### PR TITLE
fix: Replace hardcoded User model with configurable auth model

### DIFF
--- a/src/Events/TwoFactorAuthenticationEvent.php
+++ b/src/Events/TwoFactorAuthenticationEvent.php
@@ -11,14 +11,14 @@ abstract class TwoFactorAuthenticationEvent
     /**
      * The user instance.
      *
-     * @var \App\Models\User
+     * @var \Illuminate\Contracts\Auth\Authenticatable
      */
     public $user;
 
     /**
      * Create a new event instance.
      *
-     * @param  \App\Models\User  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
     public function __construct($user)

--- a/src/Models/SocialProviderUser.php
+++ b/src/Models/SocialProviderUser.php
@@ -2,7 +2,6 @@
 
 namespace Devdojo\Auth\Models;
 
-use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -45,7 +44,7 @@ class SocialProviderUser extends Model
      */
     public function user(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'user_id');
+        return $this->belongsTo(config('auth.providers.users.model'), 'user_id');
     }
 
     /**

--- a/src/Providers/DuskServiceProvider.php
+++ b/src/Providers/DuskServiceProvider.php
@@ -37,7 +37,8 @@ class DuskServiceProvider extends ServiceProvider
         });
 
         Browser::macro('createJohnDoe', function () {
-            $user = \App\Models\User::factory()->create([
+            $userModel = config('auth.providers.users.model');
+            $user = $userModel::factory()->create([
                 'email' => 'johndoe@gmail.com',
                 'password' => \Hash::make('password'),
             ]);


### PR DESCRIPTION
Fixes hardcoded `App\Models\User` references to use Laravel's configurable auth model instead.

## Changes

- **SocialProviderUser.php** — `user()` relationship now uses `config('auth.providers.users.model')`
- **TwoFactorAuthenticationEvent.php** — PHPDoc updated to use `\Illuminate\Contracts\Auth\Authenticatable` contract
- **DuskServiceProvider.php** — `createJohnDoe` macro uses config for User model

## Why

This allows the package to work correctly when applications use a custom User model path (e.g., `App\Models\Auth\User` or `Domain\Users\User`).