### PR TITLE
refactor: Simplify ViewAuthSetup middleware logic

### DIFF
--- a/src/Http/Middleware/ViewAuthSetup.php
+++ b/src/Http/Middleware/ViewAuthSetup.php
@@ -3,16 +3,19 @@
 namespace Devdojo\Auth\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Symfony\Component\HttpFoundation\Response;
 
 class ViewAuthSetup
 {
-    public function handle($request, Closure $next)
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
     {
-        if (! app()->isLocal() && ! Gate::allows('viewAuthSetup')) {
-            return redirect('auth/login');
-        }
-
         if (app()->isLocal() || Gate::allows('viewAuthSetup')) {
             return $next($request);
         }

--- a/tests/Feature/ViewAuthSetupMiddlewareTest.php
+++ b/tests/Feature/ViewAuthSetupMiddlewareTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Support\Facades\Gate;
+
+it('allows access to setup pages in local environment', function () {
+    // Simulate local environment
+    app()->detectEnvironment(fn () => 'local');
+
+    $this->get('/auth/setup')
+        ->assertStatus(200);
+});
+
+it('denies access to setup pages in production without permission', function () {
+    // Simulate production environment
+    app()->detectEnvironment(fn () => 'production');
+
+    // Gate returns false by default
+    $this->get('/auth/setup')
+        ->assertStatus(403);
+});
+
+it('allows access to setup pages in production with viewAuthSetup permission', function () {
+    // Simulate production environment
+    app()->detectEnvironment(fn () => 'production');
+
+    // Grant permission via Gate
+    Gate::define('viewAuthSetup', fn ($user = null) => true);
+
+    $this->get('/auth/setup')
+        ->assertStatus(200);
+});
+
+it('protects all setup routes with middleware', function () {
+    // Simulate production environment without permission
+    app()->detectEnvironment(fn () => 'production');
+
+    $setupRoutes = [
+        '/auth/setup',
+        '/auth/setup/appearance',
+        '/auth/setup/providers',
+        '/auth/setup/language',
+        '/auth/setup/settings',
+    ];
+
+    foreach ($setupRoutes as $route) {
+        $this->get($route)
+            ->assertStatus(403, "Route {$route} should be protected");
+    }
+});


### PR DESCRIPTION
Simplifies the `ViewAuthSetup` middleware by removing redundant conditions and adds comprehensive tests.

## Before
```php
if (! app()->isLocal() && ! Gate::allows('viewAuthSetup')) {
    return redirect('auth/login');
}

if (app()->isLocal() || Gate::allows('viewAuthSetup')) {
    return $next($request);
}

abort(403);
```

## After
```php
if (app()->isLocal() || Gate::allows('viewAuthSetup')) {
    return $next($request);
}

abort(403);
```

## Changes
- Removed redundant first condition (was equivalent to negation of second)
- Added proper `Request` and `Response` type hints
- Added PHPDoc block matching other middleware in the package
- Changed unauthorized response from `redirect('auth/login')` to `abort(403)` — more secure and doesn't assume route exists
- **Added 4 new tests** for the middleware covering:
  - Local environment access
  - Production without permission (403)
  - Production with `viewAuthSetup` Gate permission (allowed)
  - All setup routes are protected

## Security
**Behavior:**
- ✅ Local environment: always allowed
- ✅ Production: requires `viewAuthSetup` Gate permission
- ✅ Unauthorized users: 403 Forbidden (was redirect to potentially non-existent route)

All 61 tests pass (57 original + 4 new middleware tests).